### PR TITLE
fix: add file/url to form data last

### DIFF
--- a/packages/core/sender/src/xhrSender/prepareFormData.js
+++ b/packages/core/sender/src/xhrSender/prepareFormData.js
@@ -39,10 +39,8 @@ const getFormFileField = (fd: FormData, items: BatchItem[], options: SendOptions
     });
 };
 
-export default (items: BatchItem[], options: SendOptions) => {
+const prepareFormData = (items: BatchItem[], options: SendOptions) => {
     const fd = new FormData();
-
-    getFormFileField(fd, items, options);
 
     if (options.params) {
         Object.entries(options.params)
@@ -50,5 +48,9 @@ export default (items: BatchItem[], options: SendOptions) => {
                 addToFormData(fd, key, val));
     }
 
+    getFormFileField(fd, items, options);
+
     return fd;
 };
+
+export default prepareFormData;

--- a/packages/core/sender/src/xhrSender/tests/prepareFormData.test.js
+++ b/packages/core/sender/src/xhrSender/tests/prepareFormData.test.js
@@ -124,9 +124,9 @@ describe("prepareFormData tests", () => {
             }
         });
 
-        expect(mockFormDataSet).toHaveBeenCalledWith(paramName, items[0].url);
         expect(mockFormDataSet).toHaveBeenCalledWith("foo", "bar");
         expect(mockFormDataSet).toHaveBeenCalledWith("extra", true);
+        expect(mockFormDataSet).toHaveBeenCalledWith(paramName, items[0].url);
     });
 
     it("should use delete & append if no set", () => {


### PR DESCRIPTION
apparently S3 stops reading data as soon as it reaches the file in the payload
and doesnt get to the other params