### PR TITLE
Update link for SendMethod references

### DIFF
--- a/packages/core/uploader/README.md
+++ b/packages/core/uploader/README.md
@@ -82,7 +82,7 @@ uploader.add(myFile);
 | enhancer             | [UploaderEnhancer](../../uploader/src/types.js#L37) | undefined    | uploader [enhancer](../../../README.md#enhancer) function
 | concurrent           | boolean       | false          | issue multiple upload requests simultaneously
 | maxConcurrent        | number        | 2              | maximum allowed simultaneous requests
-| send                 | [SendMethod](../../shared/src/types.js#L100) | @rpldy/sender | how to send files to the server
+| send                 | [SendMethod](../sender/src/types.js#L38) | @rpldy/sender | how to send files to the server
 | sendWithFormData     | boolean       | true           | upload is sent as part of [formdata](https://developer.mozilla.org/en-US/docs/Web/API/FormData) - when true, additional params can be sent along with uploaded data
 
 ## Uploader API

--- a/packages/ui/uploady/README.md
+++ b/packages/ui/uploady/README.md
@@ -59,7 +59,7 @@ It provides multiple hooks that enable more advanced features and data for clien
 | enhancer             | [UploaderEnhancer](../../core/uploader/src/types.js#L37) | undefined    | uploader [enhancer](../../../README.md#enhancer) function
 | concurrent           | boolean       | false          | issue multiple upload requests simultaneously
 | maxConcurrent        | number        | 2              | maximum allowed simultaneous requests
-| send                 | [SendMethod](../../core/shared/src/types.js#L100) | @rpldy/sender | how to send files to the server
+| send                 | [SendMethod](../../core/sender/src/types.js#L38) | @rpldy/sender | how to send files to the server
 | sendWithFormData     | boolean       | true           | upload is sent as part of [formdata](https://developer.mozilla.org/en-US/docs/Web/API/FormData) - when true, additional params can be sent along with uploaded data
 | **Uploady Options**
 | debug                | boolean        | false | enable console logs from uploady packages


### PR DESCRIPTION
This PR fixes the broken references in the documentation for `SendMethod`.

Did not create an issue for this, since the contributing guidelines seem to be meant for code changes.