### PR TITLE
Add missing useFileInput type to @rpldy/uploady

### DIFF
--- a/packages/ui/uploady/types/index.d.ts
+++ b/packages/ui/uploady/types/index.d.ts
@@ -1,8 +1,11 @@
 import * as React from "react";
 import { UploadyProps }  from "@rpldy/shared-ui";
+import type { InputRef } from "@rpldy/shared-ui";
 
 export * from "@rpldy/shared-ui";
 
 export const Uploady: React.ComponentType<UploadyProps>;
 
 export default Uploady;
+
+export const useFileInput: (fileInputRef: InputRef) => void;


### PR DESCRIPTION
The package `@rpldy/uploady` exports the hook `useFileInput` 

https://github.com/rpldy/react-uploady/blob/7322c105c56fe6d221d258a52ab456a0a9b6fb93/packages/ui/uploady/src/index.js#L6

but does not export any corresponding types causing TypeScript to complain. This pull request adds the missing type for `useFileInput`.

### Screenshot

![image](https://user-images.githubusercontent.com/1242663/106342100-77b41e80-6254-11eb-8985-fbe41efd9859.png)

