### PR TITLE
feat: warn about uploady context version mix

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 node_modules/
+jest.config.js
 *.story.js
 *.stories.js
 *.mock.js

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -51,7 +51,7 @@ module.exports = {
         });
 
         config.plugins.push(new webpack.DefinePlugin({
-            "rpldyVersion": JSON.stringify(config.mode !== "development" ? await getCurrentNpmVersion() : ["DEV"] ),
+            "BUILD_TIME_VERSION": JSON.stringify(config.mode !== "development" ? await getCurrentNpmVersion() : ["DEV"] ),
             "LOCAL_PORT": `"${process.env.LOCAL_PORT}"`,
         }));
 

--- a/.storybook/welcome.story.js
+++ b/.storybook/welcome.story.js
@@ -70,7 +70,7 @@ export const WelcomeReactUploady = () => {
             <h2>Welcome to React-Uploady Storybook</h2>
 
             <h4>Current Version</h4>
-            {rpldyVersion.map((v) => <span className="version" key={v}>{v}</span>)}
+            {BUILD_TIME_VERSION.map((v) => <span className="version" key={v}>{v}</span>)}
         </Container>
 
         <h3>Useful Links:</h3>

--- a/bundle.config.js
+++ b/bundle.config.js
@@ -6,7 +6,8 @@ const path = require("path"),
     fs = require("fs-extra"),
     webpack = require("webpack"),
     _ = require("lodash"),
-    VirtualModulePlugin = require("virtual-module-webpack-plugin");
+    VirtualModulePlugin = require("virtual-module-webpack-plugin"),
+    uploadyPkg = require("./packages/ui/uploady/package.json");
 
 const PKGS = {
     LIFE_EVENTS: "@life-events",
@@ -22,6 +23,8 @@ let licenseContent;
 
 module.exports = {
     org: "@rpldy/",
+
+    version: uploadyPkg.version,
 
     library: "rpldy",
 
@@ -50,7 +53,7 @@ module.exports = {
                 config: {
                     externals: ["react", "react-dom"],
                 },
-                maxSize: 15000,
+                maxSize: 16000,
             },
 
             /**
@@ -108,7 +111,7 @@ module.exports = {
                         },
                     };
                 },
-                maxSize: 25000,
+                maxSize: 26000,
             },
 
             //TODO: find a way to make this work with global object assignment (wepackages/tus-sender/src/tusSender/initTusUpload/createUpload.js:88:94bpack externals root)

--- a/jest.config.js
+++ b/jest.config.js
@@ -44,7 +44,7 @@ module.exports = async () => {
                 statements: 98
             }
         },
-        "collectCoverageFrom": [
+        collectCoverageFrom: [
             "<rootDir>/packages/**/src/**/*.js",
             "!<rootDir>/packages/**/**/*.test.js",
             "!<rootDir>/packages/**/*.story.js",
@@ -56,10 +56,13 @@ module.exports = async () => {
             "<rootDir>/packages/(?:.+?)/lib/",
             "<rootDir>/cypress"
         ],
-        "setupFilesAfterEnv": [
+        setupFilesAfterEnv: [
             "./node_modules/jest-enzyme/lib/index.js",
             "<rootDir>/test/jestSetup.js"
         ],
-        "testEnvironment": "jest-environment-jsdom-global",
+        testEnvironment: "jest-environment-jsdom-global",
+        globals: {
+            "BUILD_TIME_VERSION": "0.0.0",
+        }
     };
 };

--- a/packages/ui/shared/src/UploadyContext.js
+++ b/packages/ui/shared/src/UploadyContext.js
@@ -1,6 +1,8 @@
 // @flow
 import React from "react";
 import { logger, invariant } from "@rpldy/shared";
+import { registerUploadyContextVersion  } from "./uploadyVersion";
+
 import type { UploaderType, CreateOptions } from "@rpldy/uploader";
 import type { UploadInfo, UploadOptions, GetExact } from "@rpldy/shared";
 import type { EventCallback } from "@rpldy/life-events";
@@ -105,6 +107,10 @@ export const createContextApi =
         };
 
         const hasUploader = () => !!uploader;
+
+        //We register the version on the global object to be able to warn devs when they're using packages from different uploady versions
+        //causing the context not to be available
+        registerUploadyContextVersion();
 
         return {
             hasUploader,

--- a/packages/ui/shared/src/assertContext.js
+++ b/packages/ui/shared/src/assertContext.js
@@ -1,10 +1,20 @@
 // @flow
 import { invariant } from "@rpldy/shared";
+import { getIsVersionRegisteredAndDifferent, getRegisteredVersion } from "./uploadyVersion";
+
 import type { UploadyContextType } from "./types";
 
-export const ERROR_MSG = "Uploady - valid UploadyContext not found. Make sure you render inside <Uploady>";
+export const ERROR_MSG = "Uploady - Valid UploadyContext not found. Make sure you render inside <Uploady>";
+export const DIFFERENT_VERSION_ERROR_MSG = `Uploady - Valid UploadyContext not found.
+You may be using packages of different Uploady versions. <Uploady> and all other packages using the context provider must be of the same version: %s`;
 
 export default (context: ?UploadyContextType): UploadyContextType => {
+    invariant(
+        !getIsVersionRegisteredAndDifferent(),
+        DIFFERENT_VERSION_ERROR_MSG,
+        getRegisteredVersion(),
+    );
+
     invariant(
         context && context.hasUploader(),
         ERROR_MSG

--- a/packages/ui/shared/src/tests/assertContext.test.js
+++ b/packages/ui/shared/src/tests/assertContext.test.js
@@ -1,7 +1,9 @@
-import assertContext, { ERROR_MSG } from "../assertContext";
+import assertContext, { ERROR_MSG, DIFFERENT_VERSION_ERROR_MSG } from "../assertContext";
+import { getIsVersionRegisteredAndDifferent, getRegisteredVersion } from "../uploadyVersion";
+
+jest.mock("../uploadyVersion");
 
 describe("assertContext tests", () => {
-
     it("should throw if no context", () => {
         expect(assertContext).toThrow(ERROR_MSG);
     });
@@ -12,7 +14,18 @@ describe("assertContext tests", () => {
         }).toThrow(ERROR_MSG);
     });
 
+    it("should throw if different version", () => {
+        getIsVersionRegisteredAndDifferent.mockReturnValueOnce(true);
+        getRegisteredVersion.mockReturnValueOnce("1");
+
+        expect(() => {
+            assertContext(null);
+        }).toThrow(DIFFERENT_VERSION_ERROR_MSG.replace("%s", "1"));
+    });
+
     it("should not throw when has context and uploader", () => {
+        getIsVersionRegisteredAndDifferent.mockReturnValueOnce(false);
+
         const context = { hasUploader: () => true };
 
         const result = assertContext(context);

--- a/packages/ui/shared/src/tests/uploadyVersion.test.js
+++ b/packages/ui/shared/src/tests/uploadyVersion.test.js
@@ -1,0 +1,32 @@
+import {
+    GLOBAL_VERSION_SYM,
+    getVersion,
+    registerUploadyContextVersion,
+    getRegisteredVersion,
+    getIsVersionRegisteredAndDifferent,
+} from "../uploadyVersion";
+
+describe("uploadyVersion tests", () => {
+
+    beforeEach(() => {
+        delete window[GLOBAL_VERSION_SYM];
+    });
+
+    it("should return global version", () => {
+        expect(getVersion()).toBe("0.0.0");
+    });
+
+    it("should register and retrieve", () => {
+        expect(getRegisteredVersion()).toBeUndefined();
+        registerUploadyContextVersion();
+        expect(getRegisteredVersion()).toBe("0.0.0");
+    });
+
+    it("should return true if same version as registered", () => {
+        expect(getIsVersionRegisteredAndDifferent()).toBe(false);
+        registerUploadyContextVersion();
+        expect(getIsVersionRegisteredAndDifferent()).toBe(false);
+        global[GLOBAL_VERSION_SYM] = "diff";
+        expect(getIsVersionRegisteredAndDifferent()).toBe(true);
+    });
+});

--- a/packages/ui/shared/src/uploadyVersion.js
+++ b/packages/ui/shared/src/uploadyVersion.js
@@ -1,0 +1,37 @@
+// @flow
+import { hasWindow } from "@rpldy/shared";
+
+declare var BUILD_TIME_VERSION: string;
+
+/* istanbul ignore next */
+// eslint-disable-next-line no-undef
+const VERSION = BUILD_TIME_VERSION || "";
+
+export const GLOBAL_VERSION_SYM: symbol = Symbol.for("_rpldy-version_");
+
+const getVersion = (): string => VERSION;
+
+const getRegisteredVersion = (): string => {
+    /* istanbul ignore next */
+    const global = hasWindow() ? window : process;
+    // $FlowIgnore
+    return global[GLOBAL_VERSION_SYM];
+};
+
+const registerUploadyContextVersion = (): void => {
+    const global = hasWindow() ? window : process;
+    //$FlowIgnore
+    global[GLOBAL_VERSION_SYM] = VERSION;
+};
+
+const getIsVersionRegisteredAndDifferent = (): boolean => {
+    const registeredVersion = getRegisteredVersion();
+    return !!registeredVersion && registeredVersion !== VERSION;
+};
+
+export {
+    getVersion,
+    getRegisteredVersion,
+    registerUploadyContextVersion,
+    getIsVersionRegisteredAndDifferent,
+};


### PR DESCRIPTION
in case @rpldy/uploady and for ex @rpldy/upload-preview have different versions
React will not provide the context to the consumer because @rpldy/upload-preview  will have its own version (inside node_modules)
This will log an error to the console about the mix