### PR TITLE
feat: ignore undefined params in formdata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
                     - cy-install-{{ checksum "yarn.lock" }}
             - run-e2e
             - store_artifacts:
-                  path: cypress/results
+                  path: cypress/results/screenshots
             - store_test_results:
                   path: cypress/results
 workflows:

--- a/.storybook/cypressAddon/cypressDecorator.js
+++ b/.storybook/cypressAddon/cypressDecorator.js
@@ -11,8 +11,13 @@ export default makeDecorator({
 		if (win) {
 		    win.__cypressEnv = process.env.NODE_ENV;
 			win.__cypressResults = win.__cypressResults || { storyLog: []};
-			//clear story log on each story render
+
+            //clear story log on each story render
 			win.__cypressResults.storyLog = [];
+            delete win.__extUploadOptions;
+            delete win.__extPreSendOptions;
+
+            //TODO: this isnt a good practice to keep these special params in different places in the code. Need to refactor to cleaner solution
 		}
 
 		return getStory(context);

--- a/cypress/integration/uploady/Uploady-undefined-param-spec.js
+++ b/cypress/integration/uploady/Uploady-undefined-param-spec.js
@@ -1,0 +1,63 @@
+import intercept from "../intercept";
+import uploadFile from "../uploadFile";
+
+describe("Uploady - Undefined params", () => {
+    const fileName = "flower.jpg";
+
+    before(() => {
+        cy.visitStory("uploady", "with-header-from-file-name&knob-destination_Upload Destination=local&knob-mock send delay_Upload Destination=1000&knob-multiple files_Upload Settings=true&knob-group files in single request_Upload Settings=&knob-max in group_Upload Settings=2&knob-auto upload on add_Upload Settings=true");
+    });
+
+    const testUndefinedNotPassed = () => {
+        cy.wait(100);
+
+        uploadFile(fileName, () => {
+            cy.wait("@uploadReq")
+                .interceptFormData((formData) => {
+                    expect(formData["file"]).to.eq("flower.jpg");
+                    expect(formData).not.to.contain.keys("empty");
+                });
+
+            cy.storyLog().assertFileItemStartFinish(fileName, 1);
+        });
+    };
+
+    it("should not pass undefined param to formData from upload options", () => {
+        intercept("http://localhost:4000/upload");
+
+        cy.setUploadOptions({ params: { empty: undefined } });
+
+        testUndefinedNotPassed();
+    });
+
+    it("should not pass undefined param to formData from requestPreSend", () => {
+        intercept("http://localhost:4000/upload");
+
+        cy.setPreSendOptions({ params: { empty: undefined } });
+
+        testUndefinedNotPassed();
+    });
+
+    it("should pass undefined param with formDataAllowUndefined", () => {
+        intercept("http://localhost:4000/upload");
+
+        cy.setUploadOptions({
+            formDataAllowUndefined: true,
+        });
+
+        cy.setPreSendOptions({ params: { empty: undefined } });
+
+        cy.wait(100);
+
+        uploadFile(fileName, () => {
+            cy.wait("@uploadReq")
+                .interceptFormData((formData) => {
+                    expect(formData["file"]).to.eq("flower.jpg");
+                    expect(formData).to.contain.keys("empty");
+                    expect(formData["empty"]).to.eq("undefined");
+                });
+
+            cy.storyLog().assertFileItemStartFinish(fileName, 1);
+        });
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -3,4 +3,4 @@ import "cypress-intercept-formdata";
 import "./storyLog";
 import "./visitStory";
 import "./pasteFile";
-
+import "./setUploadOptions";

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -15,6 +15,8 @@ declare namespace Cypress {
         storyLog: () => StoryLog,
         visitStory: (component: string, storyName: string, canvas?: boolean) => void;
         pasteFile: (fixtureName: string, times?: number, mimeType?: string) => Chainable;
+        setUploadOptions: (options: Object) => void;
+        setPreSendOptions: (options: Object) => void;
     }
 
     interface Chainable<Subject = Interception> {

--- a/cypress/support/setUploadOptions.js
+++ b/cypress/support/setUploadOptions.js
@@ -1,0 +1,15 @@
+Cypress.Commands.add("setUploadOptions", (options) =>
+    cy.wrap(window.parent)
+        .then((w) => {
+            if (w._setUploadOptions) {
+                w._setUploadOptions(options);
+            } else {
+                w.__extUploadOptions = options;
+            }
+        }));
+
+Cypress.Commands.add("setPreSendOptions", (options) =>
+    cy.wrap(window.parent)
+        .then((w) => {
+            w.__extPreSendOptions = options;
+        }));

--- a/packages/core/sender/src/types.js
+++ b/packages/core/sender/src/types.js
@@ -15,6 +15,7 @@ export type SendOptions = {
     withCredentials: ?boolean,
     formatGroupParamName: ?FormatParamGroupNameMethod,
     sendWithFormData?: boolean,
+    formDataAllowUndefined?: boolean,
     formatServerResponse?: FormatServerResponseMethod,
 };
 

--- a/packages/core/sender/src/xhrSender/prepareFormData.js
+++ b/packages/core/sender/src/xhrSender/prepareFormData.js
@@ -11,13 +11,13 @@ import type { SendOptions } from "../types";
 const addToFormData = (fd, name, ...rest) => {
     //rest = [value, fileName = undefined]
     if ("set" in fd) {
-        // $FlowFixMe - ignore flow for not allowing FileLike here
+        //$FlowExpectedError[speculation-ambiguous] - ignore flow for not allowing FileLike here
         fd.set(name, ...rest);
     } else {
         if ("delete" in fd) {
             fd.delete(name);
         }
-        // $FlowFixMe - ignore flow for not allowing FileLike here
+        //$FlowExpectedError[speculation-ambiguous] - ignore flow for not allowing FileLike here
         fd.append(name, ...rest);
     }
 };
@@ -44,8 +44,11 @@ const prepareFormData = (items: BatchItem[], options: SendOptions): FormData => 
 
     if (options.params) {
         Object.entries(options.params)
-            .forEach(([key, val]: [string, any]) =>
-                addToFormData(fd, key, val));
+            .forEach(([key, val]: [string, any]) => {
+                if (options.formDataAllowUndefined || val !== undefined) {
+                    addToFormData(fd, key, val);
+                }
+            });
     }
 
     getFormFileField(fd, items, options);

--- a/packages/core/sender/src/xhrSender/tests/prepareFormData.test.js
+++ b/packages/core/sender/src/xhrSender/tests/prepareFormData.test.js
@@ -15,7 +15,6 @@ describe("prepareFormData tests", () => {
     });
 
     const testPrepare = (items, options) => {
-
         options = {
             paramName,
             ...options
@@ -25,7 +24,6 @@ describe("prepareFormData tests", () => {
     };
 
     it("should create FD for File", () => {
-
         const items = [{
             file: {
                 name: "aaa",
@@ -114,7 +112,6 @@ describe("prepareFormData tests", () => {
     });
 
     it("should add extra params", () => {
-
         const items = [{ url: "https://test.com" }];
 
         testPrepare(items, {
@@ -172,5 +169,41 @@ describe("prepareFormData tests", () => {
 
         expect(mockFormDataSet).not.toHaveBeenCalled();
         expect(fdAppend).toHaveBeenCalledWith(paramName, items[0].file, items[0].file.name);
+    });
+
+    describe("undefined values", () => {
+        it("should not add undefined values by default", () => {
+            const items = [{
+                file: {
+                    name: "aaa",
+                }
+            }];
+
+            testPrepare(items, {
+                params: {
+                    "foo": undefined,
+                }
+            });
+
+            expect(mockFormDataSet).toHaveBeenCalledTimes(1);
+        });
+
+        it("should add undefined values when formDataAllowUndefined = true", () => {
+            const items = [{
+                file: {
+                    name: "aaa",
+                }
+            }];
+
+            testPrepare(items, {
+                formDataAllowUndefined: true,
+                params: {
+                    "foo": undefined,
+                }
+            });
+
+            expect(mockFormDataSet).toHaveBeenCalledTimes(2);
+            expect(mockFormDataSet).toHaveBeenCalledWith("foo", undefined);
+        });
     });
 });

--- a/packages/core/sender/types/index.d.ts
+++ b/packages/core/sender/types/index.d.ts
@@ -1,21 +1,8 @@
 import {
     BatchItem,
-    FormatParamGroupNameMethod,
     UploadData,
-    FormatServerResponseMethod,
+    SendOptions
 } from "@rpldy/shared";
-
-export interface SendOptions  {
-    method: string;
-    paramName: string;
-    params?: Record<string, unknown>;
-    headers?: Record<string, unknown>;
-    forceJsonResponse?: boolean;
-    withCredentials?: boolean;
-    formatGroupParamName?: FormatParamGroupNameMethod;
-    sendWithFormData?: boolean;
-    formatServerResponse?: FormatServerResponseMethod;
-}
 
 export interface XhrSendConfig {
     preRequestHandler: (
@@ -48,3 +35,7 @@ export const getXhrSend: (config?: XhrSendConfig) => SendMethod;
 export const send: SendMethod;
 
 export default send;
+
+export {
+    SendOptions,
+};

--- a/packages/core/shared/src/types.js
+++ b/packages/core/shared/src/types.js
@@ -116,6 +116,8 @@ export type UploadOptions = {|
 	withCredentials?: boolean,
     //whether file/url data will be sent as part of formdata (default: true)
     sendWithFormData?: boolean,
+    //whether to include params with undefined value (default: false)
+    formDataAllowUndefined?: boolean,
     //optional function to create the batch item's uploadResponse from the raw xhr response
     formatServerResponse?: FormatServerResponseMethod,
 |};

--- a/packages/core/shared/types/index.d.ts
+++ b/packages/core/shared/types/index.d.ts
@@ -12,23 +12,28 @@ export type FormatServerResponseMethod = (response: string, status: number, head
 
 export type FileFilterMethod = (file: unknown, index: number, files: unknown[]) => boolean;
 
-export interface UploadOptions {
+export interface SendOptions  {
+    method: string;
+    paramName: string;
+    params?: Record<string, unknown>;
+    headers?: Record<string, unknown>;
+    forceJsonResponse?: boolean;
+    withCredentials?: boolean;
+    formatGroupParamName?: FormatParamGroupNameMethod;
+    sendWithFormData?: boolean;
+    formDataAllowUndefined?: boolean;
+    formatServerResponse?: FormatServerResponseMethod;
+}
+
+export interface UploadOptions extends Partial<SendOptions>{
     autoUpload?: boolean;
     clearPendingOnAdd?: boolean;
     formatGroupParamName?: FormatParamGroupNameMethod;
     grouped?: boolean;
     maxGroupSize?: number;
     fileFilter?: FileFilterMethod;
-
-    //send options
     destination?: Destination;
     inputFieldName?: string;
-    method?: string;
-    params?: Record<string, unknown>;
-    forceJsonResponse?: boolean;
-    withCredentials?: boolean;
-    sendWithFormData?: boolean;
-    formatServerResponse?: FormatServerResponseMethod,
 }
 
 export enum BATCH_STATES {

--- a/packages/core/uploader/README.md
+++ b/packages/core/uploader/README.md
@@ -85,6 +85,7 @@ uploader.add(myFile);
 | send                 | [SendMethod](../sender/src/types.js#L38) | @rpldy/sender | how to send files to the server
 | sendWithFormData     | boolean       | true           | upload is sent as part of [formdata](https://developer.mozilla.org/en-US/docs/Web/API/FormData) - when true, additional params can be sent along with uploaded data
 | formatServerResponse | [FormatServerResponseMethod](../shared/src/types.js#L40) | undefined | function to create the batch item's uploadResponse from the raw xhr response
+| formDataAllowUndefined | boolean     | false          | //whether to include params with undefined value
 
 ## Uploader API
 

--- a/packages/core/uploader/src/batchItemsSender.js
+++ b/packages/core/uploader/src/batchItemsSender.js
@@ -52,6 +52,7 @@ const createBatchItemsSender = (): ItemsSender => {
             headers: destination?.headers,
             sendWithFormData: batchOptions.sendWithFormData,
             formatServerResponse: batchOptions.formatServerResponse,
+            formDataAllowUndefined: batchOptions.formDataAllowUndefined
         }, throttledProgress);
     };
 

--- a/packages/core/uploader/src/defaults.js
+++ b/packages/core/uploader/src/defaults.js
@@ -21,4 +21,5 @@ export const DEFAULT_OPTIONS: Object = devFreeze({
     destination: {},
     send: null,
     sendWithFormData: true,
+    formDataAllowUndefined: false,
 });

--- a/packages/core/uploader/types/index.d.ts
+++ b/packages/core/uploader/types/index.d.ts
@@ -1,7 +1,6 @@
 import {
     UploadOptions,
     Batch,
-    FormatParamGroupNameMethod,
     Trigger,
     UploadInfo,
 } from "@rpldy/shared";
@@ -10,17 +9,6 @@ import {
 } from "@rpldy/sender";
 
 import { OnAndOnceMethod, OffMethod } from "@rpldy/life-events";
-
-export type SendOptions = {
-    method: string;
-    paramName: string;
-    params: Record<string, unknown>;
-    headers?: Record<string, unknown>;
-    forceJsonResponse?: boolean;
-    withCredentials?: boolean;
-    formatGroupParamName?: FormatParamGroupNameMethod;
-    sendWithFormData: boolean;
-};
 
 export type UploadAddMethod = (files: UploadInfo | UploadInfo[], addOptions?: UploadOptions) => Promise<void>
 
@@ -85,3 +73,5 @@ export enum UPLOADER_EVENTS {
 }
 
 export default createUploader;
+
+export { SendOptions } from "@rpldy/sender";

--- a/packages/ui/uploady/Uploady.stories.js
+++ b/packages/ui/uploady/Uploady.stories.js
@@ -9,6 +9,7 @@ import {
     useStoryUploadySetup,
     getCsfExport,
     StoryAbortButton,
+
     type CsfExport,
 } from "../../../story-helpers";
 import { getUploadyVersion } from "@rpldy/shared-ui";
@@ -46,7 +47,7 @@ const ContextUploadButton = () => {
 };
 
 export const ButtonWithContextApi = (): Node => {
-    const { enhancer, destination, multiple, grouped, groupSize } = useStoryUploadySetup();
+    const { enhancer, destination, multiple, grouped, groupSize, extOptions } = useStoryUploadySetup();
 
     return <Uploady
         debug
@@ -54,7 +55,9 @@ export const ButtonWithContextApi = (): Node => {
         destination={destination}
         enhancer={enhancer}
         grouped={grouped}
-        maxGroupSize={groupSize}>
+        maxGroupSize={groupSize}
+        {...extOptions}
+    >
 
         version <span id="uploady-version">{getUploadyVersion()}</span>
         <br/>
@@ -322,7 +325,8 @@ const ExampleRequestPreSend = () => {
                     headers: {
                         "x-file-names-lengths": namesLengths,
                     }
-                }
+                },
+                ...(window.parent.__extPreSendOptions || {})
             }
         };
     });
@@ -331,7 +335,7 @@ const ExampleRequestPreSend = () => {
 };
 
 export const withHeaderFromFileName = (): Node => {
-    const { enhancer, destination, grouped, groupSize, autoUpload } = useStoryUploadySetup();
+    const { enhancer, destination, grouped, groupSize, autoUpload, extOptions } = useStoryUploadySetup();
 
     return <Uploady
         debug
@@ -341,7 +345,9 @@ export const withHeaderFromFileName = (): Node => {
         enhancer={enhancer}
         grouped={grouped}
         maxGroupSize={groupSize}
-        autoUpload={autoUpload}>
+        autoUpload={autoUpload}
+        {...extOptions}
+    >
         <ExampleRequestPreSend/>
         <ContextUploadButton/>
     </Uploady>;

--- a/packages/ui/uploady/types/index.test-d.tsx
+++ b/packages/ui/uploady/types/index.test-d.tsx
@@ -21,7 +21,23 @@ const testUseFileInput = (): JSX.Element => <Uploady debug>
     <MyComponent />
 </Uploady>;
 
+const testWithSendProps = (): JSX.Element => (
+    <Uploady
+        formDataAllowUndefined
+        forceJsonResponse
+        autoUpload={false}
+        destination={{
+            url: "https://somewhere.over/the/rainbow",
+            params: {
+                foo: "bar"
+            }
+        }}
+    >
+        <div>test</div>
+    </Uploady>
+);
 export {
     testMyApp,
-    testUseFileInput
+    testUseFileInput,
+    testWithSendProps
 };

--- a/story-helpers/index.js
+++ b/story-helpers/index.js
@@ -46,3 +46,5 @@ export { default as getCsfExport } from "./getCsfExport";
 export type { CsfExport } from "./getCsfExport";
 
 export { default as dropZoneCss } from "./dropZoneCss";
+
+export { useExternalUploadOptionsProvider } from "./useExternalUploadOptionsProvider";

--- a/story-helpers/useExternalUploadOptionsProvider.js
+++ b/story-helpers/useExternalUploadOptionsProvider.js
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+const useExternalUploadOptionsProvider = () => {
+    const [cyOptions, setCyOptions] = useState(() => {
+        return window.parent.__extUploadOptions || null;
+    });
+
+    window.parent._setUploadOptions = setCyOptions;
+
+    return cyOptions;
+};
+
+export {
+    useExternalUploadOptionsProvider,
+};

--- a/story-helpers/useStoryUploadySetup.js
+++ b/story-helpers/useStoryUploadySetup.js
@@ -5,6 +5,7 @@ import { getMockSenderEnhancer } from "@rpldy/mock-sender";
 import { DESTINATION_TYPES, KNOB_GROUPS} from "./consts";
 import { actionLogEnhancer, isCypress } from "./uploadyStoryLogger";
 import { isProd } from "./helpers";
+import { useExternalUploadOptionsProvider } from "./useExternalUploadOptionsProvider";
 
 console.log(`** React Uploady - storybook helper running in ${isProd ? "production" : "development"} mode. **`);
 
@@ -111,6 +112,8 @@ const useStoryUploadySetup = (options = {}) => {
         groupSize = !options.noGroup && number("max in group", 2, {}, KNOB_GROUPS.SETTINGS),
         autoUpload = boolean("auto upload on add", true, KNOB_GROUPS.SETTINGS);
 
+    const extOptions = useExternalUploadOptionsProvider();
+
     return useMemo(() => ({
             multiple,
             destination,
@@ -119,8 +122,9 @@ const useStoryUploadySetup = (options = {}) => {
             groupSize,
             destinationType,
             autoUpload,
+            extOptions
         }),
-        [type, multiple, grouped, groupSize, destination, enhancer, destinationType, autoUpload]);
+        [type, multiple, grouped, groupSize, destination, enhancer, destinationType, autoUpload, extOptions]);
 };
 
 export default useStoryUploadySetup;


### PR DESCRIPTION
unless new flag: formatServerResponse is used and set to true
this changes the default behavior of accepting params with undefined value from preSend hook/event

fixes #263 