### PR TITLE
feat: enable dnd on element contained

### DIFF
--- a/packages/ui/upload-drop-zone/README.md
+++ b/packages/ui/upload-drop-zone/README.md
@@ -14,7 +14,7 @@
 Drop zone (container) component to initiate file and folder content uploads
 Supports individual files as well as recursively iterating over a dropped directory to upload its contents.
  
-Uses [html-dir-content](https://www.npmjs.com/package/html-dir-content) to process the files/directories in the dnd events ([DataTransferItem](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem)). 
+Uses [html-dir-content](https://www.npmjs.com/package/html-dir-content) to process the files/directories in the DnD events ([DataTransferItem](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem)). 
 
 Can easily be combined with other D&D solutions. 
 
@@ -36,17 +36,18 @@ Drop Zones can use different configuration overrides that supersede the options 
 
 ## Props
 
-| Name (* = mandatory) | Type                                                   | Default    | Description                                                                                              |
-|----------------------|--------------------------------------------------------|------------|----------------------------------------------------------------------------------------------------------|
-| id                   | string                                                 | undefined  | id attribute to pass to the container element                                                            |
-| className            | string                                                 | undefined  | the class attribute to pass to the container element                                                     |
-| onDragOverClassName  | string                                                 | undefined  | class name to add to the container when dragged over                                                     |
-| dropHandler          | [DropHandlerMethod](src/types.js#L4)                   | undefined  | override default handler that returns the drop result (ex: files). May return a promise                  | 
-| htmlDirContentParams | Object                                                 | undefined  | will be passed as is to html-dir-content. See [docs](https://www.npmjs.com/package/html-dir-content#api) |
-| shouldRemoveDragOver | [ShouldRemoveDragOverMethod](src/types.js#L6)          | undefined  | callback to help identify when to remove the onDragOverClassName. Receives the dragleave event           |
-| shouldHandleDrag     | boolean or  [ShuoldHandleDragMethod](src/types.js#8)   | undefined  | Whether drag&drop should be handled, either boolean or method returning boolean  |     
-| children             | React.Node                                             | undefined  | child element(s) to render inside the container                                                          |
-| extraProps           | Object                                                 | undefined  | any other props to pass to the div component (with spread)                                               |
+| Name (* = mandatory) | Type                                                | Default   | Description                                                                                              |
+|----------------------|-----------------------------------------------------|-----------|----------------------------------------------------------------------------------------------------------|
+| id                   | string                                              | undefined | id attribute to pass to the container element                                                            |
+| className            | string                                              | undefined | the class attribute to pass to the container element                                                     |
+| onDragOverClassName  | string                                              | undefined | class name to add to the container when dragged over                                                     |
+| dropHandler          | [DropHandlerMethod](src/types.js#L4)                | undefined | override default handler that returns the drop result (ex: files). May return a promise                  | 
+| htmlDirContentParams | Object                                              | undefined | will be passed as is to html-dir-content. See [docs](https://www.npmjs.com/package/html-dir-content#api) |
+| shouldRemoveDragOver | [ShouldRemoveDragOverMethod](src/types.js#L6)       | undefined | callback to help identify when to remove the onDragOverClassName. Receives the dragleave event           |
+| shouldHandleDrag     | boolean or [ShuoldHandleDragMethod](src/types.js#8) | undefined | Whether drag&drop should be handled, either boolean or method returning boolean                          |
+| enableOnContains     | boolean                                             | true      | By default will handle drag-enter for children of the container and not just the container itself        |
+| children             | React.Node                                          | undefined | child element(s) to render inside the container                                                          |
+| extraProps           | Object                                              | undefined | any other props to pass to the div component (with spread)                                               |
 
 In addition, most [UploadOptions](../../core/shared/src/types.js#L104) props can be passed to UploadDropZone.
 In order to override configuration passed to the parent Uploady component. 

--- a/packages/ui/upload-drop-zone/UploadDropZone.stories.js
+++ b/packages/ui/upload-drop-zone/UploadDropZone.stories.js
@@ -244,6 +244,20 @@ const StyledFullScreenDropZone = styled(UploadDropZone)`
        display: flex;
        align-items: center;
        justify-content: center;
+       gap: 10px;
+       position: relative;
+       flex-wrap: wrap;
+
+       h1 {
+           position: absolute;
+           top: 50%;
+           left: 50%;
+           transform: translate(-50%, -50%);
+       }
+       .content-box {
+           flex-grow: 1;
+           height:  100%;
+       }
    }
 
     &.drag-over .dropIndicator {
@@ -268,6 +282,7 @@ export const WithFullScreen = (): Node => {
                     {...extOptions}
     >
         <StyledFullScreenDropZone
+            // enableOnContains={false}
             id="upload-drop-zone"
             onDragOverClassName="drag-over"
             shouldRemoveDragOver={({ target }) => target === indicatorRef.current}
@@ -280,6 +295,18 @@ export const WithFullScreen = (): Node => {
             }}
         >
             <div className="content">
+                {[
+                    { color: "#f19898", title: "A" },
+                    { color: "#143b15", title: "B" },
+                    { color: "#27569b", title: "C" },
+                    { color: "#f1d898", title: "D" },
+                    { color: "#9b1a63", title: "E" },
+                    { color: "#42eee8", title: "F" },
+                ].map(({ color, title }) => <div
+                    key={title}
+                    className="content-box"
+                    style={{ backgroundColor: color }}>{title}</div>)}
+
                 <h1>Drop files here</h1>
             </div>
             <div className="dropIndicator" aria-hidden ref={indicatorRef} />

--- a/packages/ui/upload-drop-zone/src/UploadDropZone.js
+++ b/packages/ui/upload-drop-zone/src/UploadDropZone.js
@@ -11,6 +11,10 @@ const getShouldHandleDrag = (e, shouldHandle) => isEmpty(shouldHandle) ||
     shouldHandle === true ||
     (isFunction(shouldHandle) && shouldHandle(e));
 
+const isOnTarget = (e, containerElm, allowContains) => {
+    return e.target === containerElm || (allowContains && containerElm?.contains(e.target));
+};
+
 const UploadDropZone: React$AbstractComponent<UploadDropZoneProps, ?HTMLDivElement> = forwardRef<UploadDropZoneProps, ?HTMLDivElement>(
     ({
          className,
@@ -21,6 +25,7 @@ const UploadDropZone: React$AbstractComponent<UploadDropZoneProps, ?HTMLDivEleme
          htmlDirContentParams,
          shouldRemoveDragOver,
          shouldHandleDrag,
+         enableOnContains = true,
          extraProps,
          ...uploadOptions
      }, ref) => {
@@ -58,15 +63,17 @@ const UploadDropZone: React$AbstractComponent<UploadDropZoneProps, ?HTMLDivEleme
         }, [upload, dropFileHandler, uploadOptionsRef]);
 
         const onDragEnter = useCallback((e) => {
-            if (getShouldHandleDrag(e, shouldHandleDrag)) {
-                dragLeaveTrackerRef.current =
-                    (!dragLeaveTrackerRef.current && e.target === containerRef.current);
+            const isHandling = getShouldHandleDrag(e, shouldHandleDrag) &&
+                isOnTarget(e, containerRef.current, enableOnContains);
+
+            if (isHandling) {
+                dragLeaveTrackerRef.current = true;
 
                 if (containerRef.current && onDragOverClassName) {
                     containerRef.current.classList.add(onDragOverClassName);
                 }
             }
-        }, [onDragOverClassName, containerRef, shouldHandleDrag]);
+        }, [onDragOverClassName, containerRef, shouldHandleDrag, enableOnContains]);
 
         const onDragOver = useCallback((e) => {
             if (dragLeaveTrackerRef.current) {

--- a/packages/ui/upload-drop-zone/src/UploadDropZone.test.js
+++ b/packages/ui/upload-drop-zone/src/UploadDropZone.test.js
@@ -155,9 +155,9 @@ describe("UploadDropZone tests", () => {
 
         div.simulate("dragenter");
         div.simulate("dragover");
-        expect(refElm.classList.contains("drag-over")).toBe(true);
+        expect(refElm.classList.contains(onDragOverClassName)).toBe(true);
         div.simulate("dragend");
-        expect(refElm.classList.contains("drag-over")).toBe(false);
+        expect(refElm.classList.contains(onDragOverClassName)).toBe(false);
 
         div.simulate("dragenter");
 
@@ -165,10 +165,10 @@ describe("UploadDropZone tests", () => {
         span.simulate("dragenter");
         div.simulate("dragleave");
 
-        expect(refElm.classList.contains("drag-over")).toBe(true);
+        expect(refElm.classList.contains(onDragOverClassName)).toBe(false);
         div.simulate("dragenter");
         div.simulate("dragleave");
-        expect(refElm.classList.contains("drag-over")).toBe(false);
+        expect(refElm.classList.contains(onDragOverClassName)).toBe(false);
     });
 
     it("should not remove drag className if different element", () => {
@@ -192,6 +192,30 @@ describe("UploadDropZone tests", () => {
         span.simulate("dragenter");
         span.simulate("dragLeave");
         expect(refElm.classList.contains("drag-over")).toBe(true);
+    });
+
+    it("should not handle drag or add className if child and contains is disabled", () => {
+        const onDragOverClassName = "drag-over";
+
+        const { div, span, mockRef } = testDropZone({
+            enableOnContains: false,
+            onDragOverClassName,
+        }, false);
+
+        const refElm = mockRef.mock.calls[0][0];
+
+        div.simulate("dragenter");
+        div.simulate("dragover");
+        expect(refElm.classList.contains("drag-over")).toBe(true);
+        div.simulate("dragend");
+        expect(refElm.classList.contains("drag-over")).toBe(false);
+
+        span.simulate("dragenter");
+        span.simulate("dragover");
+        expect(refElm.classList.contains("drag-over")).toBe(false);
+
+        div.simulate("dragend");
+        expect(refElm.classList.contains("drag-over")).toBe(false);
     });
 
     it("should add & remove drag className with shouldRemoveDragOver callback", () => {

--- a/packages/ui/upload-drop-zone/src/types.js
+++ b/packages/ui/upload-drop-zone/src/types.js
@@ -20,6 +20,7 @@ export type UploadDropZoneProps =  {|
     htmlDirContentParams?: Object,
     shouldRemoveDragOver?: ShouldRemoveDragOverMethod,
     shouldHandleDrag?: ShouldHandleDrag,
+    enableOnContains?: boolean,
     extraProps?: Object,
     children?: React$Node,
 |};

--- a/packages/ui/upload-drop-zone/types/index.d.ts
+++ b/packages/ui/upload-drop-zone/types/index.d.ts
@@ -20,7 +20,8 @@ export interface UploadDropZoneProps extends UploadOptions {
     dropHandler?: DropHandlerMethod;
     htmlDirContentParams?: Record<string, unknown>;
     shouldRemoveDragOver?: ShouldRemoveDragOverMethod;
-    shouldHandleDrag?: ShouldHandleDrag,
+    shouldHandleDrag?: ShouldHandleDrag;
+    enableOnContains?: boolean;
     extraProps?: Record<string, unknown>;
     children?: JSX.Element | JSX.Element[];
 }


### PR DESCRIPTION
add new drop-zone prop: enableOnContains to opt-out of contained check and only enable on direct drag to container