### PR TITLE
fix: bug with item handling after async batch start

### DIFF
--- a/cypress/integration/uploady/Uploady-cancel-with-async-presend-spec.js
+++ b/cypress/integration/uploady/Uploady-cancel-with-async-presend-spec.js
@@ -1,6 +1,13 @@
 import { interceptWithHandler } from "../intercept";
 import uploadFile, { uploadFileTimes } from "../uploadFile";
-import { ITEM_ABORT, ITEM_FINISH, ITEM_START, WAIT_X_SHORT, WAIT_MEDIUM, BATCH_ABORT } from "../../constants";
+import {
+    ITEM_ABORT,
+    ITEM_FINISH,
+    ITEM_START,
+    WAIT_X_SHORT,
+    WAIT_MEDIUM,
+    BATCH_ABORT,
+} from "../../constants";
 
 describe("Uploady - Cancel Upload with long running async pre-send", () => {
     const fileName = "flower.jpg";
@@ -96,7 +103,7 @@ describe("Uploady - Cancel Upload with long running async pre-send", () => {
 
             cy.wait(WAIT_MEDIUM);
 
-            cy.storyLog().assertLogPattern(ITEM_START, { times: 2 });
+            cy.storyLog().assertLogPattern(ITEM_START, { times: 1 });
             cy.storyLog().assertLogPattern(ITEM_ABORT, { times: 1 });
             cy.storyLog().assertLogPattern(ITEM_FINISH, { times: 1 });
         }, 2);

--- a/packages/core/uploader/src/queue/batchHelpers.js
+++ b/packages/core/uploader/src/queue/batchHelpers.js
@@ -147,6 +147,11 @@ const loadNewBatchForItem = (queue: QueueState, itemId: string): Promise<boolean
         .then(({ cancelled }: ItemsSendData) => {
             let alreadyFinished = false;
 
+            queue.updateState((state) => {
+                const pendingFlagIndex = state.batchesStartPending.indexOf(batch.id);
+                state.batchesStartPending.splice(pendingFlagIndex, 1);
+            });
+
             if (!cancelled) {
                 //in case of async batch start, its possible that when batch is aborted, items are already removed from queue
                 alreadyFinished = !getIsItemExists(queue, itemId);
@@ -154,12 +159,6 @@ const loadNewBatchForItem = (queue: QueueState, itemId: string): Promise<boolean
                 if (!alreadyFinished) {
                     queue.updateState((state) => {
                         state.currentBatch = batch.id;
-
-                        const pendingFlagIndex = state.batchesStartPending.indexOf(batch.id);
-
-                        if (~pendingFlagIndex) {
-                            state.batchesStartPending.splice(pendingFlagIndex, 1);
-                        }
                     });
                 }
             }

--- a/packages/core/uploader/src/queue/itemHelpers.js
+++ b/packages/core/uploader/src/queue/itemHelpers.js
@@ -1,4 +1,7 @@
 // @flow
+import { ITEM_FINALIZE_STATES } from "../consts";
+
+import type { BatchItem } from "@rpldy/shared";
 import type { QueueState } from "./types";
 
 const finalizeItem = (queue: QueueState, id: string, delItem: boolean = false) => {
@@ -26,7 +29,11 @@ const finalizeItem = (queue: QueueState, id: string, delItem: boolean = false) =
 const getIsItemExists = (queue: QueueState, itemId: string): boolean =>
     !!queue.getState().items[itemId];
 
+const getIsItemFinalized = (item: BatchItem): boolean =>
+    ITEM_FINALIZE_STATES.includes(item.state);
+
 export {
     finalizeItem,
     getIsItemExists,
+    getIsItemFinalized,
 };

--- a/packages/core/uploader/src/queue/preSendPrepare.js
+++ b/packages/core/uploader/src/queue/preSendPrepare.js
@@ -1,5 +1,6 @@
 // @flow
 import { getMerge, isSamePropInArrays, logger, triggerUpdater } from "@rpldy/shared";
+import { getIsItemFinalized } from "./itemHelpers";
 
 import type { BatchItem } from "@rpldy/shared";
 import type { QueueState } from "./types";
@@ -61,7 +62,10 @@ const persistPrepareResponse = (queue, prepared) => {
         queue.updateState((state) => {
             //update potentially changed data back into queue state
             prepared.items.forEach((i) => {
-                state.items[i.id] = i;
+                //update item if it is NOT finished (ex: aborted)
+                if (!getIsItemFinalized(state.items[i.id])) {
+                    state.items[i.id] = i;
+                }
             });
 
             state.batches[prepared.items[0].batchId].batchOptions = prepared.options;

--- a/packages/core/uploader/src/queue/processFinishedRequest.js
+++ b/packages/core/uploader/src/queue/processFinishedRequest.js
@@ -72,7 +72,7 @@ const processFinishedRequest = (queue: QueueState, finishedData: FinishData[], n
         finalizeItem(queue, id);
     });
 
-    //ensure finished batches are remove from state
+    //ensure finished batches are removed from state
     cleanUpFinishedBatches(queue);
 
     next(queue);

--- a/packages/core/uploader/src/queue/tests/itemHelpers.test.js
+++ b/packages/core/uploader/src/queue/tests/itemHelpers.test.js
@@ -1,3 +1,4 @@
+import { FILE_STATES } from "@rpldy/shared";
 import getQueueState from "./mocks/getQueueState.mock";
 import * as itemHelpers from "../itemHelpers";
 
@@ -97,6 +98,21 @@ describe("itemHelpers tests", () => {
         ])("for %s should return %s", (id, expected) => {
             const result = itemHelpers.getIsItemExists(queueState, id);
             expect(result).toBe(expected);
+        });
+    });
+
+    describe("getIsItemFinalized tests", () => {
+        it.each(
+            [
+                [FILE_STATES.CANCELLED, true],
+                [FILE_STATES.FINISHED, true],
+                [FILE_STATES.ABORTED, true],
+                [FILE_STATES.ERROR, true],
+                [FILE_STATES.ADDED, false],
+                [FILE_STATES.PENDING, false],
+                [FILE_STATES.UPLOADING, false],
+            ])("for %s should return %s", (state, result) => {
+            expect(itemHelpers.getIsItemFinalized({ state })).toBe(result);
         });
     });
 });

--- a/packages/core/uploader/src/queue/tests/mocks/batchHelpers.mock.js
+++ b/packages/core/uploader/src/queue/tests/mocks/batchHelpers.mock.js
@@ -7,7 +7,8 @@ const mockIsNewBatchStarting = jest.fn(),
 	mockGetBatchDataFromItemId = jest.fn(),
 	mockCleanUpFinishedBatches = jest.fn(),
 	mockGetIsBatchReady = jest.fn(),
-    mockFailBatchForItem = jest.fn();
+    mockFailBatchForItem = jest.fn(),
+    mockIsItemBatchStartPending = jest.fn();
 
 const helpersMock = {
 	isNewBatchStarting: mockIsNewBatchStarting,
@@ -20,6 +21,7 @@ const helpersMock = {
 	getBatchDataFromItemId: mockGetBatchDataFromItemId,
 	cleanUpFinishedBatches: mockCleanUpFinishedBatches,
     getIsBatchReady: mockGetIsBatchReady,
+    isItemBatchStartPending: mockIsItemBatchStartPending,
 };
 
 jest.doMock("../../batchHelpers", () => helpersMock);

--- a/packages/core/uploader/src/queue/tests/uploaderQueue.test.js
+++ b/packages/core/uploader/src/queue/tests/uploaderQueue.test.js
@@ -206,6 +206,7 @@ describe("queue tests", () => {
                 itemQueue: {},
                 batchQueue: [],
                 currentBatch: null,
+                batchesStartPending: [],
                 batches: {},
                 items: {},
                 activeIds: [],

--- a/packages/core/uploader/src/queue/types.js
+++ b/packages/core/uploader/src/queue/types.js
@@ -10,6 +10,7 @@ export type State = {|
 	itemQueue: { [string]: string[] },
     batchQueue: string[],
 	currentBatch: ?string,
+    batchesStartPending: string[],
 	batches: { [string]: BatchData },
 	items: { [string]: BatchItem },
 	activeIds: Array<string | string[]>,

--- a/packages/core/uploader/src/queue/uploaderQueue.js
+++ b/packages/core/uploader/src/queue/uploaderQueue.js
@@ -28,6 +28,7 @@ const createUploaderQueue = (
         itemQueue: { },
         batchQueue: [],
         currentBatch: null,
+        batchesStartPending: [],
         batches: {},
         items: {},
         activeIds: [],


### PR DESCRIPTION
its possible to abort items while batch start is pending handling by userland code In this case, queue processing should take into account that items may have already finalized before batch_start response returns