### PR TITLE
feat: expose upload total size for progress event

### DIFF
--- a/packages/core/shared/src/types.js
+++ b/packages/core/shared/src/types.js
@@ -51,6 +51,7 @@ type BatchItemBase = {|
 	completed: number,
 	//bytes uploaded
 	loaded: number,
+	total: number,
 	recycled: boolean,
     previousBatch: ?string;
 |};

--- a/packages/core/shared/src/types.js
+++ b/packages/core/shared/src/types.js
@@ -51,6 +51,7 @@ type BatchItemBase = {|
 	completed: number,
 	//bytes uploaded
 	loaded: number,
+    //total bytes
 	total: number,
 	recycled: boolean,
     previousBatch: ?string;

--- a/packages/core/shared/types/index.d.ts
+++ b/packages/core/shared/types/index.d.ts
@@ -80,6 +80,7 @@ interface BatchItemBase {
     uploadStatus: number;
     completed: number;
     loaded: number;
+    total: number;
     recycled: boolean;
     previousBatch?: string;
 }

--- a/packages/core/uploader/src/batchItemsSender.js
+++ b/packages/core/uploader/src/batchItemsSender.js
@@ -11,23 +11,25 @@ import type { Batch, BatchItem } from "@rpldy/shared";
 import type { TriggerMethod } from "@rpldy/life-events";
 import type { ItemsSender, UploaderCreateOptions, BatchItemSenderSendMethod } from "./types";
 
-const reportItemsProgress = (items: BatchItem[], completed: number, loaded: number, trigger: TriggerMethod) => {
+const reportItemsProgress = (items: BatchItem[], completed: number, loaded: number, total: number, trigger: TriggerMethod) => {
     items.forEach((item: BatchItem) => {
         logger.debugLog(`uploady.uploader.processor: file: ${item.id} progress event: loaded(${loaded}) - completed(${completed})`);
 
         trigger(SENDER_EVENTS.ITEM_PROGRESS,
             item,
             completed,
-            loaded);
+            loaded,
+            total);
     });
 };
 
 const onItemUploadProgress = (items: BatchItem[], batch: Batch, e: ProgressEvent, trigger: TriggerMethod) => {
     const completed = Math.min(((e.loaded / e.total) * 100), 100),
         completedPerItem = completed / items.length,
-        loadedAverage = e.loaded / items.length;
+        loadedAverage = e.loaded / items.length,
+        total = e.total;
 
-    reportItemsProgress(items, completedPerItem, loadedAverage, trigger);
+    reportItemsProgress(items, completedPerItem, loadedAverage, total, trigger);
 
     trigger(SENDER_EVENTS.BATCH_PROGRESS, batch);
 };

--- a/packages/core/uploader/src/batchItemsSender.js
+++ b/packages/core/uploader/src/batchItemsSender.js
@@ -26,10 +26,9 @@ const reportItemsProgress = (items: BatchItem[], completed: number, loaded: numb
 const onItemUploadProgress = (items: BatchItem[], batch: Batch, e: ProgressEvent, trigger: TriggerMethod) => {
     const completed = Math.min(((e.loaded / e.total) * 100), 100),
         completedPerItem = completed / items.length,
-        loadedAverage = e.loaded / items.length,
-        total = e.total;
+        loadedAverage = e.loaded / items.length;
 
-    reportItemsProgress(items, completedPerItem, loadedAverage, total, trigger);
+    reportItemsProgress(items, completedPerItem, loadedAverage, e.total, trigger);
 
     trigger(SENDER_EVENTS.BATCH_PROGRESS, batch);
 };

--- a/packages/core/uploader/src/queue/processFinishedRequest.js
+++ b/packages/core/uploader/src/queue/processFinishedRequest.js
@@ -54,7 +54,7 @@ const processFinishedRequest = (queue: QueueState, finishedData: FinishData[], n
 
             if (info.state === FILE_STATES.FINISHED && item.completed < 100) {
                 //ensure we trigger progress event with completed = 100 for all items
-                queue.handleItemProgress(item, 100, item.file ? item.file.size : 0);
+                queue.handleItemProgress(item, 100, item.file ? item.file.size : 0, item.file ? item.file.size : 0);
             }
 
             if (FILE_STATE_TO_EVENT_MAP[item.state]) {

--- a/packages/core/uploader/src/queue/processFinishedRequest.js
+++ b/packages/core/uploader/src/queue/processFinishedRequest.js
@@ -54,7 +54,8 @@ const processFinishedRequest = (queue: QueueState, finishedData: FinishData[], n
 
             if (info.state === FILE_STATES.FINISHED && item.completed < 100) {
                 //ensure we trigger progress event with completed = 100 for all items
-                queue.handleItemProgress(item, 100, item.file ? item.file.size : 0, item.file ? item.file.size : 0);
+                const size = item.file?.size || 0;
+                queue.handleItemProgress(item, 100, size , size);
             }
 
             if (FILE_STATE_TO_EVENT_MAP[item.state]) {

--- a/packages/core/uploader/src/queue/tests/processFinishedRequest.test.js
+++ b/packages/core/uploader/src/queue/tests/processFinishedRequest.test.js
@@ -95,7 +95,7 @@ describe("onRequestFinished tests", () => {
 
 		const item = test.queueState.getState().items["u1"];
 		expect(test.queueState.handleItemProgress).toHaveBeenCalledWith(
-			item, 100, item.file.size);
+			item, 100, item.file.size, item.file.size);
 	});
 
 	it("should handle url item progress if not complete === 100", async () => {
@@ -103,7 +103,7 @@ describe("onRequestFinished tests", () => {
 
 		const item = test.queueState.getState().items["u2"];
 		expect(test.queueState.handleItemProgress).toHaveBeenCalledWith(
-			item, 100, 0);
+			item, 100, 0, 0);
 	});
 
 	it("for single item should finalize if last file in batch without active id found", async () => {

--- a/packages/core/uploader/src/queue/types.js
+++ b/packages/core/uploader/src/queue/types.js
@@ -29,7 +29,7 @@ export type QueueState = {|
 	trigger: TriggerMethod,
     runCancellable: Cancellable,
 	sender: ItemsSender,
-    handleItemProgress: (BatchItem, number, number) => void,
+    handleItemProgress: (BatchItem, number, number, number) => void,
     clearAllUploads: () => void,
     clearBatchUploads: (string) => void,
 |};

--- a/packages/core/uploader/src/queue/uploaderQueue.js
+++ b/packages/core/uploader/src/queue/uploaderQueue.js
@@ -83,12 +83,13 @@ const createUploaderQueue = (
         return getBatchFromState(state, batch.id);
     };
 
-    const handleItemProgress = (item: BatchItem, completed: number, loaded: number) => {
+    const handleItemProgress = (item: BatchItem, completed: number, loaded: number, total: number) => {
         if (state.items[item.id]) {
             updateState((state: State) => {
                 const stateItem = state.items[item.id];
                 stateItem.loaded = loaded;
                 stateItem.completed = completed;
+                stateItem.total = total;
             });
 
             //trigger item progress event for the outside

--- a/packages/core/uploader/src/tests/batchItemsSender.test.js
+++ b/packages/core/uploader/src/tests/batchItemsSender.test.js
@@ -114,7 +114,8 @@ describe("batchItemsSender tests", () => {
             expect(mockTrigger).toHaveBeenNthCalledWith(i + 1, SENDER_EVENTS.ITEM_PROGRESS,
                 item,
                 (completed / test.items.length),
-                (progressEvent.loaded / test.items.length)
+                (progressEvent.loaded / test.items.length),
+                progressEvent.total
             );
         });
 


### PR DESCRIPTION
Hello

I hope you are doing well! I wanted to submit a pull request for exposing an additional 'total upload file size' parameter in the onProgress event. I believe this change will improve the project by making it easier for developers to display the total upload size of the file, which is diffrent with the local file size as described on [ProgressEvent/total](https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent/total) 

I have tested this change locally and updated the onProgress handler to use this new parameter. Please let me know if you would like me to add any additional tests or documentation.

If you feel this pull request could be improved in any way, please let me know so I can update it. I'm happy to make any edits to get this merged.

Thank you for your time and consideration. I look forward to hearing your feedback!

Let me know if you would like me to modify the language or contents of this pull request template further. I'm happy to help craft effective communication for your needs.