### PR TITLE
Update time upload paste, reduce wait time still fix flakiness

### DIFF
--- a/cypress/integration/upload-paste/UploadPaste-simple-spec.js
+++ b/cypress/integration/upload-paste/UploadPaste-simple-spec.js
@@ -1,4 +1,4 @@
-import { WAIT_MEDIUM } from "../../constants";
+import { WAIT_SHORT } from "../../constants";
 
 describe("UploadPaste - Simple", () => {
     const fileName = "flower.jpg";

--- a/cypress/integration/upload-paste/UploadPaste-simple-spec.js
+++ b/cypress/integration/upload-paste/UploadPaste-simple-spec.js
@@ -12,7 +12,7 @@ describe("UploadPaste - Simple", () => {
             .should("exist")
             .pasteFile(fileName);
 
-         cy.wait(WAIT_MEDIUM);
+         cy.wait(WAIT_SHORT);
          cy.storyLog().assertFileItemStartFinish(fileName, 1);
     });
 
@@ -22,7 +22,7 @@ describe("UploadPaste - Simple", () => {
             .should("exist")
             .pasteFile(fileName, 2);
 
-        cy.wait(WAIT_MEDIUM);
+        cy.wait(WAIT_SHORT);
         cy.storyLog().assertFileItemStartFinish(fileName, 1);
         cy.storyLog().assertFileItemStartFinish("flower2.jpg", 3);
     });


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 1500ms to 800ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving an average of 11.1% in test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.