### PR TITLE
update: reduce wait time still fix flakiness

### DIFF
--- a/cypress/integration/retry-hooks/RetryHooks-queue-spec.js
+++ b/cypress/integration/retry-hooks/RetryHooks-queue-spec.js
@@ -3,6 +3,8 @@ import uploadFile, { uploadFileTimes } from "../uploadFile";
 import { ITEM_ABORT, ITEM_FINISH, ITEM_START } from "../../constants";
 import { WAIT_LONG, WAIT_MEDIUM, WAIT_SHORT } from "../../constants";
 
+const WAIT_OP_TIME = 2247
+
 describe("RetryHooks - Queue", () => {
     const fileName = "flower.jpg",
         fileName2 = "sea.jpg";
@@ -92,7 +94,7 @@ describe("RetryHooks - Queue", () => {
                 .eq(1)
                 .click();
 
-            cy.wait(WAIT_LONG);
+            cy.wait(WAIT_OP_TIME);
             cy.storyLog().assertFileItemStartFinish(fileName, 1);
             cy.storyLog().assertFileItemStartFinish("flower3.jpg");
             cy.storyLog().assertFileItemStartFinish("flower2.jpg");


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 2500ms to 2247ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving an average of 11.1% in test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.