### PR TITLE
update: reduce wait time still fix flakiness

### DIFF
--- a/cypress/integration/chunked-sender/ChunkedSender-Progress-spec.js
+++ b/cypress/integration/chunked-sender/ChunkedSender-Progress-spec.js
@@ -17,7 +17,7 @@ describe("ChunkedSender - Progress", () => {
     it("should use chunked sender with progress events", () => {
         loadStory();
         //delay response so we dont miss events due to progress event throttling
-        interceptWithDelay(200);
+        interceptWithDelay(160);
 
         uploadFile(fileName, () => {
             cy.get("#form-submit")


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 200ms to 160ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.