### PR TITLE
fix: tus not handling correctly sendOnCreate with file smaller than chunk

### DIFF
--- a/cypress/integration/tus-uploady/TusUploady-send-data-spec.js
+++ b/cypress/integration/tus-uploady/TusUploady-send-data-spec.js
@@ -4,27 +4,29 @@ import intercept from "../intercept";
 describe("TusUploady - Send Data", () => {
     const fileName = "flower.jpg";
 
-    before(() => {
+    const loadStory = (chunkSize) => {
         cy.visitStory(
             "tusUploady",
             "simple",
             {
                 uploadUrl: "http://test.tus.com/upload",
-                chunkSize: 200000,
+                chunkSize: chunkSize,
                 uploadParams: { foo: "bar" },
                 tusResumeStorage: true,
                 tusIgnoreModifiedDateInStorage: true,
                 tusSendOnCreate: true,
             }
         );
-    });
+    }
 
-    it("should upload chunks using tus protocol with data on create", () => {
+    const runTest = (chunkSize, isFileSmallerThanChunk = false) => {
+        loadStory(chunkSize);
+
         intercept("http://test.tus.com/upload", "POST", {
             headers: {
                 "Location": "http://test.tus.com/upload/123",
                 "Tus-Resumable": "1.0.0",
-                "Upload-Offset": "200000",
+                "Upload-Offset": `${chunkSize}`,
             }
         }, "createReq");
 
@@ -44,9 +46,11 @@ describe("TusUploady - Send Data", () => {
             cy.storyLog()
                 .assertFileItemStartFinish(fileName, 1)
                 .then((startFinishEvents) => {
+
                     cy.wait("@createReq")
                         .then(({ request }) => {
-                            expect(request.headers["content-length"]).to.eq("200000");
+                            const expectedLength = request.body.byteLength < chunkSize ? request.body.byteLength : chunkSize;
+                            expect(request.headers["content-length"]).to.eq(`${expectedLength}`);
 
                             expect(request.headers["upload-metadata"])
                                 .to.eq("foo YmFy");
@@ -54,13 +58,26 @@ describe("TusUploady - Send Data", () => {
                             expect(startFinishEvents.finish.args[1].uploadResponse.location).to.eq("http://test.tus.com/upload/123");
                         });
 
-                    cy.wait("@patchReq")
-                        .then(({ request }) => {
-                            const { headers } = request;
-                            expect(headers["upload-offset"]).to.eq("200000");
-                            expect(headers["content-type"]).to.eq("application/offset+octet-stream");
-                        });
+                    if (!isFileSmallerThanChunk) {
+                        cy.wait("@patchReq")
+                            .then(({ request }) => {
+                                const { headers } = request;
+                                expect(headers["upload-offset"]).to.eq(`${chunkSize}`);
+                                expect(headers["content-type"]).to.eq("application/offset+octet-stream");
+                            });
+                    }
                 });
         }, "#upload-button");
+    };
+
+    it("should upload chunks using tus protocol with data on create - chunk size smaller than files", () => {
+        const chunkSize = 200000;
+        runTest(chunkSize);
     });
+
+    it("should upload chunks using tus protocol with data on create - file smaller than chunk size", () => {
+        const chunkSize = 2000000;
+        runTest(chunkSize, true);
+    });
+
 });

--- a/packages/core/tus-sender/src/tusSender/initTusUpload/createUpload.js
+++ b/packages/core/tus-sender/src/tusSender/initTusUpload/createUpload.js
@@ -39,8 +39,11 @@ const handleSuccessfulCreateResponse = (item: BatchItem, url: string, tusState: 
     if (options.sendDataOnCreate) {
 		const resOffset = parseInt(createResponse.getResponseHeader("Upload-Offset"));
 		offset = !isNaN(resOffset) ? resOffset : offset;
-		//consider as done when sending parallel chunk as part of the create
-		isDone = +options.parallel > 1 && offset === sentData?.size;
+        const parallelVal = +options.parallel;
+
+		//consider as done when file smaller than chunkSize or when sending parallel chunk as part of the create
+		isDone = (parallelVal < 2  && item.file.size <= offset) ||
+            (parallelVal > 1 && offset === sentData?.size);
 	}
 
     tusState.updateState((state: State) => {


### PR DESCRIPTION
in case the file uploaded is smaller than chunk when using sendOnCreate, the first request is the only request needed. no need to follow it up

fix for #759 