### PR TITLE
Update CONTRIBUTING.md to reflect pnpm and vitest usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ In order to verify there are no issues, run:
 $ pnpm test 
 ```
 
-this will run flow, lint, vitest
+this will run flow, lint, vitest, (TS) type-check
 
 each one of these has a corresponding script to run separately.
 


### PR DESCRIPTION
While following the CONTRIBUTING.md guide I ran into a few issues running `yarn` commands until I took a look at `package.json` and saw the repo now uses `pnpm` (great choice btw).

- The repo was updated to use pnpm here: https://github.com/rpldy/react-uploady/pull/611
- The repo was updated to use vitest here: https://github.com/rpldy/react-uploady/pull/604

The E2E command still needs to be updated but I haven't worked through installing and running cypress yet so I wasn't sure what the correct documentation there should be yet.