### PR TITLE
chore: update GitHub Actions and Dependabot configurations

### DIFF
--- a/.github/actions/actions-token-unused/action.yml
+++ b/.github/actions/actions-token-unused/action.yml
@@ -14,7 +14,7 @@ runs:
     steps:
       - name: Get GH Actions Tokens
         id: get-gh-actions-tokens
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
             script: |
                 const script = require('./.github/actions/actions-token/index.js');

--- a/.github/actions/npm-deprecate/action.yml
+++ b/.github/actions/npm-deprecate/action.yml
@@ -56,7 +56,7 @@ runs:
               fi
 
         -   name: Wait before deprecation
-            uses: actions/github-script@v7
+            uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
             with:
                 result-encoding: string
                 script: |

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -17,12 +17,12 @@ inputs:
 runs:
     using: composite
     steps:
-        -   uses: pnpm/action-setup@v4
+        -   uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
             with:
                 version: 9
                 run_install: false
 
-        -   uses: actions/setup-node@v6
+        -   uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
             with:
                 cache: "pnpm"
                 cache-dependency-path: "${{ inputs.dir }}/pnpm-lock.yaml"
@@ -35,7 +35,7 @@ runs:
 
         -   name: Set up Cypress binary cache
             if: ${{ inputs.with-cypress == 'true' }}
-            uses: actions/cache@v4
+            uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
             with:
                 path: ~/.cache/Cypress
                 key: ${{ runner.os }}-cypress-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/.github"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -60,8 +60,7 @@ name: Uploady Version Deprecate
         default: This version is deprecated, please upgrade to the latest version
         type: string
 permissions:
-  id-token: write
-  contents: write
+  contents: read
 defaults:
   run:
     shell: bash
@@ -70,9 +69,11 @@ jobs:
     name: Fetch Non-Deprecated Versions
     runs-on: ubuntu-latest
     if: ${{ inputs.version == '' }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.RPLDY_PAT_TOKEN }}
       - name: Prepare
@@ -105,7 +106,7 @@ jobs:
     if: ${{ inputs.version != '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Prepare

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,10 +12,10 @@ defaults:
         shell: bash
 
 permissions:
-    pull-requests: write
-    contents: write
+    contents: read
+    pull-requests: read
     actions: read
-    checks: write
+    checks: read
 
 jobs:
     code-changes:
@@ -24,7 +24,7 @@ jobs:
             IS_CODE_CHANGED: ${{ steps.check-changes.outputs.code_changed }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
                 with:
                     fetch-depth: 2
             -   name: Check for code changes
@@ -60,14 +60,14 @@ jobs:
         if: ${{ needs.code-changes.outputs.IS_CODE_CHANGED == 'true' }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             -   name: Prepare
                 uses: ./.github/actions/prepare
                 with:
                     with-cypress: true
                     with-frozen: true
             -   name: Install dependencies
-                uses: cypress-io/github-action@v6
+                uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7 # v6.10.9
                 with:
                     runTests: false
 
@@ -76,7 +76,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             -   name: Prepare
                 uses: ./.github/actions/prepare
                 with:
@@ -91,9 +91,10 @@ jobs:
         permissions:
             pull-requests: write
             contents: write
+            actions: read
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4                
+                uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             -   name: Prepare
                 uses: ./.github/actions/prepare
                 with:
@@ -104,14 +105,14 @@ jobs:
                     pnpm bundle:prod
             -   name: Cache Bundle Folder
                 id: cache-bundle
-                uses: actions/cache@v4
+                uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
                 with:
                     path: bundle
                     key: bundle-${{ runner.os }}-${{ hashFiles('bundle/**') }}
             -   name: Bundle Size Check (Overweight)
-                uses: yoavniran/overweight@v1
-                with:                    
-                    github-token: ${{ secrets.GITHUB_TOKEN }}                    
+                uses: yoavniran/overweight@ee294a046ad2637d648b7b9c67e34928c93c7806 # v1
+                with:
+                    github-token: ${{ secrets.GITHUB_TOKEN }}
                     update-baseline: true
                     report-file: overweight-report.json
                     baseline-protected-branches: "master"
@@ -122,7 +123,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             -   name: Prepare
                 uses: ./.github/actions/prepare
                 with:
@@ -132,7 +133,7 @@ jobs:
                 run: pnpm sb:build:internal
             -   name: Cache SB Build
                 id: cache-sb
-                uses: actions/cache@v4
+                uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
                 with:
                     path: .sb-static
                     key: sb-static-${{ hashFiles('lerna.json') }}-${{ github.run_id }}
@@ -142,7 +143,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             -   name: Prepare
                 uses: ./.github/actions/prepare
                 with:
@@ -155,9 +156,14 @@ jobs:
         name: Unit-Test (Vitest)
         runs-on: ubuntu-latest
         environment: "Rpldy-Build"
+        permissions:
+            contents: read
+            pull-requests: write
+            checks: write
+            actions: read
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             -   name: Prepare
                 uses: ./.github/actions/prepare
                 with:
@@ -166,9 +172,9 @@ jobs:
             -   name: unit-test
                 run: pnpm vitest:ci
             -   name: Show Report Coverage
-                uses: davelosert/vitest-coverage-report-action@v2
+                uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2
             -   name: Test Report
-                uses: dorny/test-reporter@v2
+                uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
                 if: success() || failure()
                 with:
                     name: Unit-test Report
@@ -178,7 +184,7 @@ jobs:
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             -   name: Upload Coverage (master only)
-                uses: codecov/codecov-action@v4
+                uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
                 if: ${{ github.ref_name == 'master' }}
                 with:
                     token: ${{ secrets.CODECOV_TOKEN }}
@@ -194,15 +200,20 @@ jobs:
             - sb
             - code-changes
         if: ${{ needs.code-changes.outputs.IS_CODE_CHANGED == 'true' }}
+        permissions:
+            contents: write
+            checks: write
+            actions: write
+            pull-requests: read
         steps:
             -   name: Checkout PR
-                uses: actions/checkout@v4
+                uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
                 if: ${{ github.ref_name != 'master' }}
                 with:
                     ref: ${{ github.head_ref }}
                     fetch-depth: 0
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
                 if: ${{ github.ref_name == 'master' }}
 
             -   name: Prepare
@@ -211,20 +222,20 @@ jobs:
                     with-cypress: true
                     with-frozen: true
             -   name: Restore SB Build Cache
-                uses: actions/cache@v4
+                uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
                 with:
                     path: .sb-static
                     key: sb-static-${{ hashFiles('lerna.json') }}-${{ github.run_id }}
                     restore-keys: sb-static-${{ hashFiles('lerna.json') }}-
             -   name: Restore Bundle Cache
-                uses: actions/cache@v4
+                uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
                 with:
                     path: bundle
                     key: bundle-${{ runner.os }}-
                     restore-keys: bundle-${{ runner.os }}-
             -   name: Cypress run
                 id: cypress-e2e
-                uses: cypress-io/github-action@v6
+                uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7 # v6.10.9
                 with:
                     install: false
                     start: |
@@ -252,14 +263,14 @@ jobs:
                     git commit -m "chore: update e2e weights file"
                     git push
             -   name: Store screenshots
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
                 if: failure()
                 with:
                     name: cypress-screenshots
                     path: cypress/screenshots
                     if-no-files-found: ignore
             -   name: E2E Report
-                uses: dorny/test-reporter@v2
+                uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2
                 if: success() || failure()
                 with:
                     name: E2E Report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
                     echo "🔴 Failing Job - Cant use version: (premajor, preminor, prepatch, prerelease) without selecting 'preid' value too! >> $GITHUB_STEP_SUMMARY
                     exit 1
 
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
                 with:
                     fetch-depth: 0
 
@@ -152,7 +152,7 @@ jobs:
                     git push origin ${{ steps.version-name.outputs.NEW_VERSION }}
 
             -   name: Create GH Release
-                uses: ncipollo/release-action@v1
+                uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
                 with:
                     name: ${{ steps.version-name.outputs.NEW_VERSION }}
                     body: ${{ steps.version-log.outputs.VERSION_LOG }}
@@ -161,7 +161,7 @@ jobs:
 
             -   name: Create PR for Release
                 id: pr
-                uses: peter-evans/create-pull-request@v6
+                uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
                 with:
                     title: "chore: release ${{ steps.version-name.outputs.NEW_VERSION }}"
                     body: "Automatic PR for version release: ${{ steps.version-name.outputs.NEW_VERSION }}"

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -11,7 +11,7 @@ jobs:
     stale:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/stale@v8
+            - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
               with:
                   days-before-stale: 10
                   days-before-close: 5

--- a/.github/workflows/storybook-publish.yml
+++ b/.github/workflows/storybook-publish.yml
@@ -18,7 +18,7 @@ jobs:
         name: Publish Uploady Storybook
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             -   name: Prepare
                 uses: ./.github/actions/prepare


### PR DESCRIPTION
- Updated Dependabot configuration to set weekly update intervals for npm and GitHub Actions, with specified limits on open pull requests.
- Changed action versions in various workflows to specific commits for better stability, including actions/checkout,
 actions/github-script,
 actions/setup-node, and others.
- Adjusted permissions in workflows to enhance security and functionality.

These changes aim to improve dependency management and ensure consistent behavior across workflows.