### PR TITLE
ci: add cooldown settings to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,21 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-
+    cooldown:
+      default-days: 7
+      
   - package-ecosystem: "npm"
     directory: "/.github"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Added cooldown configuration for package ecosystems. 7 days